### PR TITLE
Include static files and templates in the binary distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,14 @@ RUN apk add --update ca-certificates git curl tini=0.16.1-r0 && \
     rm -rf /var/cache/apk/*
 
 FROM common as build
-
 COPY . /opt/fiaas-mast
-
 WORKDIR /opt/fiaas-mast
-
 RUN pip wheel . --wheel-dir=/wheels/
 
 FROM common as production
-
 COPY --from=build /wheels/ /wheels/
-
 RUN pip install --no-index --find-links=/wheels/ --only-binary all /wheels/fiaas_mast*.whl
-
 USER fiaas-mast
-
 EXPOSE 5000
-
 ENTRYPOINT ["/sbin/tini", "--"]
-
 CMD ["fiaas-mast"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft fiaas_mast/static
+graft fiaas_mast/templates

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     maintainer_email="fiaas@googlegroups.com",
     version=version(),
     packages=find_packages(),
+    include_package_data=True,
     install_requires=GEN_REQ,
     extras_require={
         "dev": ['yapf==0.16.1'] + TEST_REQ + CODE_QUALITY_REQ + CI_REQ,


### PR DESCRIPTION
These files are missing from the  Docker image we're building in CI. This makes rendering of endpoints that use templates fail with a 500 error (currenly only `/status/view/*`).

I started troubleshooting by looking at the Dockerfile, so I decided to tidy the whitespace there a bit as well.