### PR TITLE
Set application annotation for spinnaker if possible

### DIFF
--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -48,6 +48,8 @@ class MetadataGenerator:
         annotations = {}
         if generator_object.spinnaker_application != "":
             annotations["moniker.spinnaker.io/application"] = generator_object.spinnaker_application
+            annotations["moniker.spinnaker.io/cluster"] = application_name
+
         # TODO: Why doesn't annotations default to a dict?
         metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
 

--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -48,8 +48,6 @@ class MetadataGenerator:
         annotations = {}
         if generator_object.spinnaker_application != "":
             annotations["moniker.spinnaker.io/application"] = generator_object.spinnaker_application
-            annotations["moniker.spinnaker.io/cluster"] = application_name
-
         # TODO: Why doesn't annotations default to a dict?
         metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
 

--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -45,8 +45,11 @@ class MetadataGenerator:
     def metadata(self, generator_object, namespace, deployment_id):
         application_name = generator_object.application_name
         labels = {"fiaas/deployment_id": deployment_id, "app": application_name}
+        annotations = {}
+        if generator_object.spinnaker_application != "":
+            annotations["moniker.spinnaker.io/application"] = generator_object.spinnaker_application
         # TODO: Why doesn't annotations default to a dict?
-        metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations={})
+        metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
 
         if generator_object.spinnaker_tags:
             metadata.annotations = self.spinnaker_annotations(generator_object)

--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -45,9 +45,7 @@ class MetadataGenerator:
     def metadata(self, generator_object, namespace, deployment_id):
         application_name = generator_object.application_name
         labels = {"fiaas/deployment_id": deployment_id, "app": application_name}
-        annotations = {}
-        if generator_object.spinnaker_application != "":
-            annotations["moniker.spinnaker.io/application"] = generator_object.spinnaker_application
+        annotations = generator_object.metadata_annotations
         # TODO: Why doesn't annotations default to a dict?
         metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
 

--- a/fiaas_mast/models.py
+++ b/fiaas_mast/models.py
@@ -7,7 +7,7 @@ Release = namedtuple("Release", [
     "original_application_name",
     "spinnaker_tags",
     "raw_tags",
-    "spinnaker_application"
+    "metadata_annotations"
 ])
 
 Status = namedtuple("Status", ["status", "info", "logs"])
@@ -18,5 +18,5 @@ ApplicationConfiguration = namedtuple("ApplicationConfiguration", [
     "original_application_name",
     "spinnaker_tags",
     "raw_tags",
-    "spinnaker_application"
+    "metadata_annotations"
 ])

--- a/fiaas_mast/models.py
+++ b/fiaas_mast/models.py
@@ -6,7 +6,8 @@ Release = namedtuple("Release", [
     "application_name",
     "original_application_name",
     "spinnaker_tags",
-    "raw_tags"
+    "raw_tags",
+    "spinnaker_application"
 ])
 
 Status = namedtuple("Status", ["status", "info", "logs"])
@@ -16,5 +17,6 @@ ApplicationConfiguration = namedtuple("ApplicationConfiguration", [
     "application_name",
     "original_application_name",
     "spinnaker_tags",
-    "raw_tags"
+    "raw_tags",
+    "spinnaker_application"
 ])

--- a/fiaas_mast/web.py
+++ b/fiaas_mast/web.py
@@ -52,7 +52,7 @@ def deploy_handler():
             data["application_name"],
             data.get("spinnaker_tags", {}),
             data.get("raw_tags", {}),
-            data.get("spinnaker_application", ""))
+            data.get("metadata_annotations", {}))
     )
     response = status(namespace, application_name, deployment_id)
     return jsonify(response._asdict()), 201, {
@@ -96,7 +96,7 @@ def generate_application():
             data["application_name"],
             data.get("spinnaker_tags", {}),
             data.get("raw_tags", {}),
-            data.get("spinnaker_application", ""))
+            data.get("metadata_annotations", {}))
     )
     return_body = {
         "manifest": application.as_dict(),
@@ -129,7 +129,7 @@ def generate_configmap_application():
             data["application_name"],
             data.get("spinnaker_tags", {}),
             data.get("raw_tags", {}),
-            data.get("spinnaker_application", ""))
+            data.get("metadata_annotations", {}))
     )
     return_body = {
         "manifest": config_map,

--- a/fiaas_mast/web.py
+++ b/fiaas_mast/web.py
@@ -51,7 +51,8 @@ def deploy_handler():
             make_safe_name(data["application_name"]),
             data["application_name"],
             data.get("spinnaker_tags", {}),
-            data.get("raw_tags", {}))
+            data.get("raw_tags", {}),
+            data.get("spinnaker_application", ""))
     )
     response = status(namespace, application_name, deployment_id)
     return jsonify(response._asdict()), 201, {
@@ -94,7 +95,8 @@ def generate_application():
             make_safe_name(data["application_name"]),
             data["application_name"],
             data.get("spinnaker_tags", {}),
-            data.get("raw_tags", {}))
+            data.get("raw_tags", {}),
+            data.get("spinnaker_application", ""))
     )
     return_body = {
         "manifest": application.as_dict(),
@@ -126,7 +128,8 @@ def generate_configmap_application():
             make_safe_name(data["application_name"]),
             data["application_name"],
             data.get("spinnaker_tags", {}),
-            data.get("raw_tags", {}))
+            data.get("raw_tags", {}),
+            data.get("spinnaker_application", ""))
     )
     return_body = {
         "manifest": config_map,

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -136,7 +136,8 @@ class TestCreateDeploymentInK8s(object):
                 APPLICATION_NAME,
                 APPLICATION_NAME,
                 SPINNAKER_TAGS,
-                RAW_TAGS
+                RAW_TAGS,
+                ""
             )
         )
 
@@ -179,7 +180,8 @@ class TestCreateDeploymentInK8s(object):
                 APPLICATION_NAME,
                 APPLICATION_NAME,
                 SPINNAKER_TAGS,
-                RAW_TAGS
+                RAW_TAGS,
+                ""
             )
         )
         expected_spec = spec_model(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -266,6 +266,7 @@ class TestApplicationGenerator(object):
         spinnaker_tags = {}
         raw_tags = {}
         spinnaker_application = "unicorn"
+        safe_application_name = make_safe_name(APPLICATION_NAME)
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -284,6 +285,7 @@ class TestApplicationGenerator(object):
         expected_application = BASE_PAASBETA_APPLICATION
         expected_application["metadata"]["namespace"] = expected_namespace
         expected_application["metadata"]["annotations"] = {"moniker.spinnaker.io/application": spinnaker_application}
+        expected_application["metadata"]["annotations"]["moniker.spinnaker.io/cluster"] = safe_application_name
 
         assert returned_application.as_dict() == expected_application
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -236,6 +236,7 @@ class TestApplicationGenerator(object):
     def test_generator_creates_object_of_given_type(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
+        spinnaker_application = ""
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -247,12 +248,44 @@ class TestApplicationGenerator(object):
                 make_safe_name(APPLICATION_NAME),
                 APPLICATION_NAME,
                 spinnaker_tags,
-                raw_tags
+                raw_tags,
+                spinnaker_application
             )
         )
         expected_paasbeta_application = BASE_PAASBETA_APPLICATION
         expected_paasbeta_application["metadata"]["namespace"] = expected_namespace
+
         assert returned_paasbeta_application.as_dict() == expected_paasbeta_application
+
+    @pytest.mark.parametrize(
+        "config,target_namespace,expected_namespace", ((VALID_DEPLOY_CONFIG_V3, ANY_NAMESPACE, ANY_NAMESPACE),
+                                                       (VALID_DEPLOY_CONFIG_V3, "custom-namespace",
+                                                        "custom-namespace"),)
+    )
+    def test_generator_annotates_moniker_application(self, config, target_namespace, expected_namespace):
+        spinnaker_tags = {}
+        raw_tags = {}
+        spinnaker_application = "unicorn"
+
+        http_client = _given_config_url_response_content_is(config)
+        generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
+        deployment_id, returned_application = generator.generate_application(
+            target_namespace=target_namespace,
+            release=Release(
+                VALID_IMAGE_NAME,
+                VALID_DEPLOY_CONFIG_URL,
+                make_safe_name(APPLICATION_NAME),
+                APPLICATION_NAME,
+                spinnaker_tags,
+                raw_tags,
+                spinnaker_application
+            )
+        )
+        expected_application = BASE_PAASBETA_APPLICATION
+        expected_application["metadata"]["namespace"] = expected_namespace
+        expected_application["metadata"]["annotations"] = {"moniker.spinnaker.io/application": spinnaker_application}
+
+        assert returned_application.as_dict() == expected_application
 
     def test_generator_adds_spinnaker_annotations(self):
         spinnaker_tags = {'foo': 'bar', 'numeric': 1337}
@@ -300,7 +333,8 @@ class TestApplicationGenerator(object):
                 make_safe_name(APPLICATION_NAME),
                 APPLICATION_NAME,
                 spinnaker_tags,
-                raw_tags
+                raw_tags,
+                ""
             )
         )
         returned_annotations = returned_paasbeta_application.spec.config["annotations"]
@@ -320,7 +354,8 @@ class TestApplicationGenerator(object):
                 make_safe_name(APPLICATION_NAME),
                 APPLICATION_NAME,
                 spinnaker_tags,
-                raw_tags
+                raw_tags,
+                ""
             )
         )
         assert "annotations" not in returned_paasbeta_application.spec.config
@@ -340,7 +375,8 @@ class TestApplicationGenerator(object):
                 make_safe_name(app_name_with_underscores),
                 app_name_with_underscores,
                 spinnaker_tags,
-                raw_tags
+                raw_tags,
+                ""
             )
         )
 
@@ -366,7 +402,8 @@ class TestConfigMapGenerator(object):
                 make_safe_name(APPLICATION_NAME),
                 APPLICATION_NAME,
                 spinnaker_tags,
-                raw_tags
+                raw_tags,
+                ""
             )
         )
         expected_configmap = BASE_CONFIGMAP

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -266,7 +266,6 @@ class TestApplicationGenerator(object):
         spinnaker_tags = {}
         raw_tags = {}
         spinnaker_application = "unicorn"
-        safe_application_name = make_safe_name(APPLICATION_NAME)
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -285,7 +284,6 @@ class TestApplicationGenerator(object):
         expected_application = BASE_PAASBETA_APPLICATION
         expected_application["metadata"]["namespace"] = expected_namespace
         expected_application["metadata"]["annotations"] = {"moniker.spinnaker.io/application": spinnaker_application}
-        expected_application["metadata"]["annotations"]["moniker.spinnaker.io/cluster"] = safe_application_name
 
         assert returned_application.as_dict() == expected_application
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -236,7 +236,6 @@ class TestApplicationGenerator(object):
     def test_generator_creates_object_of_given_type(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
-        spinnaker_application = ""
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -249,7 +248,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                spinnaker_application
+                {}
             )
         )
         expected_paasbeta_application = BASE_PAASBETA_APPLICATION
@@ -265,7 +264,7 @@ class TestApplicationGenerator(object):
     def test_generator_annotates_moniker_application(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
-        spinnaker_application = "unicorn"
+        metadata_annotation = {"moniker.spinnaker.io/application": "unicorn"}
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -278,12 +277,12 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                spinnaker_application
+                metadata_annotation
             )
         )
         expected_application = BASE_PAASBETA_APPLICATION
         expected_application["metadata"]["namespace"] = expected_namespace
-        expected_application["metadata"]["annotations"] = {"moniker.spinnaker.io/application": spinnaker_application}
+        expected_application["metadata"]["annotations"] = metadata_annotation
 
         assert returned_application.as_dict() == expected_application
 
@@ -334,7 +333,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                ""
+                {}
             )
         )
         returned_annotations = returned_paasbeta_application.spec.config["annotations"]
@@ -403,7 +402,7 @@ class TestConfigMapGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                ""
+                {}
             )
         )
         expected_configmap = BASE_CONFIGMAP

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -121,7 +121,7 @@ def test_deploy(client, status):
 
         deploy.assert_called_with(DEFAULT_NAMESPACE,
                                   Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                          RAW_TAGS))
+                                          RAW_TAGS, ""))
         status.assert_called_with("some-namespace", "app-name", "deploy_id")
 
 
@@ -135,7 +135,7 @@ def test_generate_application(client, application_endpoint):
         assert urlparse(body["status_url"]).path == "/status/default-namespace/example/deployment_id/"
         generate_application.assert_called_with(
             DEFAULT_NAMESPACE, Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                       RAW_TAGS)
+                                       RAW_TAGS, "")
         )
 
 
@@ -167,7 +167,7 @@ def test_generate_configmap(client):
 
         generate_configmap.assert_called_with(
             DEFAULT_NAMESPACE, ApplicationConfiguration("http://example.com", "example", "example", SPINNAKER_TAGS,
-                                                        RAW_TAGS)
+                                                        RAW_TAGS, "")
         )
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -121,7 +121,7 @@ def test_deploy(client, status):
 
         deploy.assert_called_with(DEFAULT_NAMESPACE,
                                   Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                          RAW_TAGS, ""))
+                                          RAW_TAGS, {}))
         status.assert_called_with("some-namespace", "app-name", "deploy_id")
 
 
@@ -135,7 +135,7 @@ def test_generate_application(client, application_endpoint):
         assert urlparse(body["status_url"]).path == "/status/default-namespace/example/deployment_id/"
         generate_application.assert_called_with(
             DEFAULT_NAMESPACE, Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                       RAW_TAGS, "")
+                                       RAW_TAGS, {})
         )
 
 
@@ -167,7 +167,7 @@ def test_generate_configmap(client):
 
         generate_configmap.assert_called_with(
             DEFAULT_NAMESPACE, ApplicationConfiguration("http://example.com", "example", "example", SPINNAKER_TAGS,
-                                                        RAW_TAGS, "")
+                                                        RAW_TAGS, {})
         )
 
 


### PR DESCRIPTION
This adds spinnaker_application as a field in the api. If this is set
then the "moniker.spinnaker.io/application" annotation will be set using
this.