### PR TITLE
Only set metadata.annotations based on metadata_annotations data

### DIFF
--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -48,13 +48,6 @@ class MetadataGenerator:
         annotations = generator_object.metadata_annotations
         # TODO: Why doesn't annotations default to a dict?
         metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
-
-        if generator_object.spinnaker_tags:
-            dict_merge(metadata.annotations, self.spinnaker_annotations(generator_object))
-
-        if generator_object.raw_tags:
-            dict_merge(metadata.annotations, self.raw_annotations(generator_object))
-
         return metadata
 
     def get_annotation_objects(self):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -390,7 +390,8 @@ class TestApplicationGenerator(object):
 class TestConfigMapGenerator(object):
     def test_configmap_generator(self):
         spinnaker_tags = {}
-        raw_tags = {'strategy.spinnaker.io/versioned': 'false'}
+        raw_tags = {}
+        metadata_annotations = {'strategy.spinnaker.io/versioned': 'false'}
 
         http_client = _given_config_url_response_content_is(APPLICATION_DATA)
         generator = ConfigMapGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -402,7 +403,7 @@ class TestConfigMapGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                {}
+                metadata_annotations
             )
         )
         expected_configmap = BASE_CONFIGMAP


### PR DESCRIPTION
The current implementation generates nested metadata.annotations. This is invalid and k8s discards annotations alltogether.