### PR TITLE
Stringify metadata annotation values

### DIFF
--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -45,7 +45,7 @@ class MetadataGenerator:
     def metadata(self, generator_object, namespace, deployment_id):
         application_name = generator_object.application_name
         labels = {"fiaas/deployment_id": deployment_id, "app": application_name}
-        annotations = generator_object.metadata_annotations
+        annotations = {k: str(v) for k, v in generator_object.metadata_annotations.items()}
         # TODO: Why doesn't annotations default to a dict?
         metadata = ObjectMeta(name=application_name, namespace=namespace, labels=labels, annotations=annotations)
         return metadata

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -264,7 +264,19 @@ class TestApplicationGenerator(object):
     def test_generator_annotates_moniker_application(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
-        metadata_annotation = {"moniker.spinnaker.io/application": "unicorn"}
+        metadata_annotation = {
+            "moniker.spinnaker.io/application": "unicorn",
+            "this_is_a_number": 3,
+            "this_is_a_floating_point_number": 3.14,
+            "this_is_a_bool": True,
+        }
+
+        expected_metadata_annotations = {
+            "moniker.spinnaker.io/application": "unicorn",
+            "this_is_a_number": "3",
+            "this_is_a_floating_point_number": "3.14",
+            "this_is_a_bool": "True",
+        }
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -282,7 +294,7 @@ class TestApplicationGenerator(object):
         )
         expected_application = BASE_PAASBETA_APPLICATION
         expected_application["metadata"]["namespace"] = expected_namespace
-        expected_application["metadata"]["annotations"] = metadata_annotation
+        expected_application["metadata"]["annotations"] = expected_metadata_annotations
 
         assert returned_application.as_dict() == expected_application
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -354,7 +354,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
-                ""
+                {}
             )
         )
         assert "annotations" not in returned_paasbeta_application.spec.config
@@ -375,7 +375,7 @@ class TestApplicationGenerator(object):
                 app_name_with_underscores,
                 spinnaker_tags,
                 raw_tags,
-                ""
+                {}
             )
         )
 


### PR DESCRIPTION
Kubernetes annotation values must be strings