### PR TITLE
Stringify config map values

### DIFF
--- a/fiaas_mast/configmap_generator.py
+++ b/fiaas_mast/configmap_generator.py
@@ -12,6 +12,6 @@ class ConfigMapGenerator(MetadataGenerator):
             "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": metadata.as_dict(),
-            "data": data
+            "data": {k: str(v) for k, v in data.items()},
         }
         return deployment_id, configmap_manifest

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -52,7 +52,10 @@ healthchecks:
 
 BASE_CONFIGMAP = {
     "data": {
-        "rules.yml": "# put your recording rules here"
+        "rules.yml": "# put your recording rules here",
+        "int_variable": "42",
+        "float_variable": "3.14",
+        "boolean_variable": "True"
     },
     "kind": "ConfigMap",
     "apiVersion": "v1",
@@ -72,6 +75,9 @@ BASE_CONFIGMAP = {
 
 APPLICATION_DATA = """
 rules.yml: '# put your recording rules here'
+int_variable: 42
+float_variable: 3.14
+boolean_variable: True
 """
 
 BASE_PAASBETA_APPLICATION = {


### PR DESCRIPTION
That's what k8s expects according to the [data spec].

[data spec]: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L5084