### PR TITLE
Support empty config maps

### DIFF
--- a/fiaas_mast/configmap_generator.py
+++ b/fiaas_mast/configmap_generator.py
@@ -12,6 +12,6 @@ class ConfigMapGenerator(MetadataGenerator):
             "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": metadata.as_dict(),
-            "data": {k: str(v) for k, v in data.items()},
+            "data": {k: str(v) for k, v in data.items()} if data else {},
         }
         return deployment_id, configmap_manifest

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -80,6 +80,28 @@ float_variable: 3.14
 boolean_variable: True
 """
 
+EMPTY_BASE_CONFIGMAP = {
+    "data": {
+    },
+    "kind": "ConfigMap",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "strategy.spinnaker.io/versioned": "false"
+        },
+        "labels": {
+            "app": "test-image",
+            "fiaas/deployment_id": "deadbeef-abba-cafe-1337-baaaaaaaaaad"
+        },
+        "name": "test-image",
+        "namespace": "any-namespace",
+        "ownerReferences": []
+    }
+}
+
+EMPTY_APPLICATION_DATA = """
+"""
+
 BASE_PAASBETA_APPLICATION = {
     "apiVersion": "schibsted.io/v1beta",
     "kind": "PaasbetaApplication",
@@ -425,6 +447,28 @@ class TestConfigMapGenerator(object):
             )
         )
         expected_configmap = BASE_CONFIGMAP
+        expected_configmap["metadata"]["namespace"] = ANY_NAMESPACE
+        assert returned_configmap == expected_configmap
+
+    def test_empty_configmap_generator(self):
+        spinnaker_tags = {}
+        raw_tags = {}
+        metadata_annotations = {'strategy.spinnaker.io/versioned': 'false'}
+
+        http_client = _given_config_url_response_content_is(EMPTY_APPLICATION_DATA)
+        generator = ConfigMapGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
+        deployment_id, returned_configmap = generator.generate_configmap(
+            target_namespace=ANY_NAMESPACE,
+            configmap_request=ApplicationConfiguration(
+                EMPTY_APPLICATION_DATA,
+                make_safe_name(APPLICATION_NAME),
+                APPLICATION_NAME,
+                spinnaker_tags,
+                raw_tags,
+                metadata_annotations
+            )
+        )
+        expected_configmap = EMPTY_BASE_CONFIGMAP
         expected_configmap["metadata"]["namespace"] = ANY_NAMESPACE
         assert returned_configmap == expected_configmap
 


### PR DESCRIPTION
Users may add empty ConfigMap files, which may lead to errors when
iterating over the keys. This patch returns an empty map in case the
ConfigMap is None.

This patch fixes the error seen in the `fiaas-mast` pod:
```
Starting new HTTPS connection (1): artifacts.schibsted.io https://artifacts.schibsted.io:443 "GET /artifactory/k8s-manifest/Yapo/pulse-service/config-dev.0.278.6129743.yml HTTP/1.1" 200 0
An error occured: AttributeError("'NoneType' object has no attribute 'items'",)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "<decorator-gen-5>", line 2, in generate_configmap_application
  File "/usr/local/lib/python3.6/site-packages/prometheus_client/core.py", line 991, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/fiaas_mast/web.py", line 132, in generate_configmap_application
    data.get("metadata_annotations", {}))
  File "/usr/local/lib/python3.6/site-packages/fiaas_mast/configmap_generator.py", line 15, in generate_configmap
    "data": {k: str(v) for k, v in data.items()},
AttributeError: 'NoneType' object has no attribute 'items'
```