### PR TITLE
Bump versions of dependencies, fixing security issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,17 @@ def version():
         warn("Error calling git: {}".format(e))
     return date_string
 
+
 GEN_REQ = [
-    "Flask==0.12.4",
-    "flask-talisman==0.5.1",
+    "Flask==1.1.1",
+    "flask-talisman==0.7.0",
     "flask-bootstrap==3.3.7.1",
-    "PyYAML==3.12",
-    "requests==2.13.0",
-    "six==1.10.0",
-    "ipaddress==1.0.18",
-    "k8s==0.10.0",
-    "prometheus_client == 0.3.1",
+    "PyYAML==5.1.2",
+    "requests==2.22.0",
+    "six==1.12.0",
+    "ipaddress==1.0.22",
+    "k8s==0.12.0",
+    "prometheus_client == 0.7.1",
 ]
 
 CODE_QUALITY_REQ = [
@@ -36,16 +37,16 @@ CODE_QUALITY_REQ = [
 ]
 
 CI_REQ = [
-    "tox==2.7.0",
-    "tox-travis==0.8",
+    "tox==3.13.2",
+    "tox-travis==0.12",
 ]
 
 TEST_REQ = [
-    'mock==2.0.0',
-    'pytest-sugar==0.8.0',
-    'pytest==3.0.7',
-    "pytest-cov==2.4.0",
-    "pytest-html==1.14.2",
+    'mock==3.0.5',
+    'pytest-sugar==0.9.2',
+    'pytest==3.10.1',
+    "pytest-cov==2.7.1",
+    "pytest-html==1.22.0",
 ]
 
 setup(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -60,6 +60,7 @@ BASE_CONFIGMAP = {
     "kind": "ConfigMap",
     "apiVersion": "v1",
     "metadata": {
+        "finalizers": [],
         "annotations": {
             "strategy.spinnaker.io/versioned": "false"
         },
@@ -86,6 +87,7 @@ EMPTY_BASE_CONFIGMAP = {
     "kind": "ConfigMap",
     "apiVersion": "v1",
     "metadata": {
+        "finalizers": [],
         "annotations": {
             "strategy.spinnaker.io/versioned": "false"
         },
@@ -106,6 +108,7 @@ BASE_PAASBETA_APPLICATION = {
     "apiVersion": "schibsted.io/v1beta",
     "kind": "PaasbetaApplication",
     "metadata": {
+        "finalizers": [],
         "labels": {
             "app": "test-image",
             "fiaas/deployment_id": "deadbeef-abba-cafe-1337-baaaaaaaaaad"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters=True
 
 [testenv]
 usedevelop=True
-deps=.[dev]
+deps=-rrequirements.txt
 setenv =
     TMP = {envtmpdir}
 passenv =


### PR DESCRIPTION
Most dependencies are bumped to latest version, all tests are still passing.
I have intentionally not updated `pytest` to latest, because pytest 4.0 has major changes that requires quite some work to handle.
