### PR TITLE
Copy tag_release script from skipper

### DIFF
--- a/bin/tag_release
+++ b/bin/tag_release
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -evuo pipefail
-go get -u -v github.com/screwdriver-cd/gitversion
-GIT_TAG=$(gitversion --prefix=v bump auto 2>&1|tail -1)
-git push https://$GITHUBKEY@github.com/fiaas/mast $GIT_TAG
+# Only do tagging on merge to master
+echo "Installing gitversion"
+url="https://github.com/screwdriver-cd/gitversion/releases/download/v1.1.3/gitversion_linux_amd64"
+install_dir="$(mktemp -d)"
+gitversion="${install_dir}/gitversion"
+curl -Lo "${gitversion}" "$url"
+chmod +x "${gitversion}"
+echo "gitversion ready at ${gitversion}"
+"${gitversion}" --version
+GIT_TAG=$("${gitversion}" --prefix=v bump auto 2>&1|tail -1)
+git push "https://${GITHUBKEY}@github.com/fiaas/skipper" "${GIT_TAG}"
 echo "successfully tagged release"
-echo $GIT_TAG
+echo "${GIT_TAG}"


### PR DESCRIPTION
This should fix the problem with gitversion not working when trying to deploy a build from master.