### PR TITLE
Ooops.. pushing tag to wrong repo is a bad idea

### DIFF
--- a/bin/tag_release
+++ b/bin/tag_release
@@ -10,6 +10,6 @@ chmod +x "${gitversion}"
 echo "gitversion ready at ${gitversion}"
 "${gitversion}" --version
 GIT_TAG=$("${gitversion}" --prefix=v bump auto 2>&1|tail -1)
-git push "https://${GITHUBKEY}@github.com/fiaas/skipper" "${GIT_TAG}"
+git push "https://${GITHUBKEY}@github.com/fiaas/mast" "${GIT_TAG}"
 echo "successfully tagged release"
 echo "${GIT_TAG}"


### PR DESCRIPTION
This could have gone badly, but we were saved by the fact that pushing a shallow clone is not allowed or something to that effect.
I think it would have been safer to push to `origin`, but I don't know how to use the env-variable (`${GITHUBKEY}`) when doing that.