### PR TITLE
Restrict http-client auth to a single origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ complain if an interpreter is not available.
 
 Set the following env variables to run locally:
 ```
+export ARTIFACTORY_ORIGIN="https://artifactory.yourdomain.com"
 export ARTIFACTORY_USER="user.name@schibsted.com"
 export ARTIFACTORY_PWD="artifactory-api-key"
 export APISERVER_TOKEN="foo"

--- a/fiaas_mast/config.py
+++ b/fiaas_mast/config.py
@@ -25,9 +25,12 @@ class Config(object):
 
         self.ARTIFACTORY_USER = os.environ.get('ARTIFACTORY_USER')
         self.ARTIFACTORY_PWD = os.environ.get('ARTIFACTORY_PWD')
-        if self.ARTIFACTORY_USER is None or self.ARTIFACTORY_PWD is None:
+        self.ARTIFACTORY_ORIGIN = os.environ.get('ARTIFACTORY_ORIGIN')
+        if self.ARTIFACTORY_USER is None or self.ARTIFACTORY_PWD is None or self.ARTIFACTORY_ORIGIN is None:
             raise RuntimeError(
-                'You need to pass the \'ARTIFACTORY_USER\' and \'ARTIFACTORY_PWD\' environment variables')
+                'You need to pass the \'ARTIFACTORY_USER\', \'ARTIFACTORY_PWD\' and \'ARTIFACTORY_ORIGIN\' '
+                'environment variables'
+            )
         self.scheme = os.environ.get('URL_SCHEME', 'https')
 
     def get_apiserver_token(self):

--- a/helm/fiaas-mast/templates/deployment.yaml
+++ b/helm/fiaas-mast/templates/deployment.yaml
@@ -79,6 +79,11 @@ spec:
             secretKeyRef:
               name: {{.Release.Name}}-secret
               key: artifactory_password
+        - name: ARTIFACTORY_ORIGIN
+          valueFrom:
+            secretKeyRef:
+              name: {{.Release.Name}}-secret
+              key: artifactory_origin
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm/fiaas-mast/templates/secret.yaml
+++ b/helm/fiaas-mast/templates/secret.yaml
@@ -32,3 +32,4 @@ type: Opaque
 data:
   artifactory_user: {{ .Values.secrets.artifactoryUser | b64enc | quote }}
   artifactory_password: {{ .Values.secrets.artifactoryPassword | b64enc | quote }}
+  artifactory_origin: {{ .Values.secrets.artifactoryOrigin | b64enc | quote }}

--- a/helm/fiaas-mast/values.yaml
+++ b/helm/fiaas-mast/values.yaml
@@ -38,3 +38,4 @@ annotations: {} # can be used to set custom annotations on every resource
 secrets: # Must be set by user
   artifactoryUser: replace_me
   artifactoryPassword: replace_me
+  artifactoryOrigin: replace_me

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,6 +27,7 @@ DEFAULT_CONFIG = {
     'APISERVER_CA_CERT': "/path/to/default.crt",
     'ARTIFACTORY_USER': "default_username",
     'ARTIFACTORY_PWD': "default_password",
+    'ARTIFACTORY_ORIGIN': "https://artifactory.example.com",
 }
 
 
@@ -63,5 +64,6 @@ class TestApp(object):
         monkeypatch.setenv('APISERVER_CA_CERT', "/path/to/cert.crt")
         monkeypatch.setenv('ARTIFACTORY_USER', "default_username")
         monkeypatch.setenv('ARTIFACTORY_PWD', "default_password")
+        monkeypatch.setenv('ARTIFACTORY_ORIGIN', "https://artifactory.example.com")
         app = create_app()
         assert app.config['APISERVER_TOKEN'] == token

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,22 +25,26 @@ class TestConfig(object):
         certificate = "/path/to/the/ca.crt"
         username = "artifactory_username"
         password = "artifactory_password"
+        origin = "https://artifactory.example.com"
         monkeypatch.setenv("APISERVER_TOKEN", token)
         monkeypatch.setenv("APISERVER_CA_CERT", certificate)
         monkeypatch.setenv("ARTIFACTORY_USER", username)
         monkeypatch.setenv("ARTIFACTORY_PWD", password)
+        monkeypatch.setenv("ARTIFACTORY_ORIGIN", origin)
 
         config = Config()
         assert config.APISERVER_TOKEN == token
         assert config.APISERVER_CA_CERT == certificate
         assert config.ARTIFACTORY_USER == username
         assert config.ARTIFACTORY_PWD == password
+        assert config.ARTIFACTORY_ORIGIN == origin
 
     def test_k8s_token_is_read_from_file_when_env_is_not_defined(self, monkeypatch):
         token = "token"
         monkeypatch.setenv("APISERVER_CA_CERT", "/path/to/the/ca.crt")
         monkeypatch.setenv("ARTIFACTORY_USER", "username")
         monkeypatch.setenv("ARTIFACTORY_PWD", "password")
+        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
 
         with mock.patch("builtins.open", mock.mock_open(read_data=token)), mock.patch("os.path.exists") as exists:
             exists.return_value = True
@@ -52,6 +56,7 @@ class TestConfig(object):
         monkeypatch.setenv("APISERVER_TOKEN", "token")
         monkeypatch.setenv("ARTIFACTORY_USER", "username")
         monkeypatch.setenv("ARTIFACTORY_PWD", "password")
+        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
 
         with mock.patch("os.path.exists") as exists:
             exists.return_value = True
@@ -63,6 +68,7 @@ class TestConfig(object):
         monkeypatch.setenv("APISERVER_CA_CERT", certificate)
         monkeypatch.setenv("ARTIFACTORY_USER", "username")
         monkeypatch.setenv("ARTIFACTORY_PWD", "password")
+        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
 
         with pytest.raises(RuntimeError):
             config = Config()
@@ -72,6 +78,7 @@ class TestConfig(object):
         monkeypatch.setenv("APISERVER_TOKEN", "thetoken")
         monkeypatch.setenv("ARTIFACTORY_USER", "username")
         monkeypatch.setenv("ARTIFACTORY_PWD", "password")
+        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
 
         with pytest.raises(RuntimeError):
             config = Config()


### PR DESCRIPTION
This fixes a security issue that meant any config-URL supplied to
mast would have the artifactory credentials attached in requests
sent to it, potentially revealing them to a third-party.
It introduces a new, mandatory, config option, `ARTIFACTORY_ORIGIN`,
which is compared against the origin (scheme+netloc, using urlparse
terminology), and only when the request is to the same origin will
the credentials be attached.