### PR TITLE
Raise client error in case of empty application config

### DIFF
--- a/fiaas_mast/application_generator.py
+++ b/fiaas_mast/application_generator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .common import select_models, generate_random_uuid_string
+from .common import select_models, generate_random_uuid_string, ClientError
 from .metadata_generator import MetadataGenerator
 
 
@@ -34,6 +34,8 @@ class ApplicationGenerator(MetadataGenerator):
 
     def spec(self, release):
         config = self.download_config(release.config_url)
+        if not config:
+            raise ClientError("Invalid config: {}".format(release.config_url))
 
         super().merge_tags(release, config)
 


### PR DESCRIPTION
For an empty application config file, mast threw an error from
trying to access one of the dict properties, which results in a
generic 500 error to the client. This checks for an empty config,
and raises a ClientError containing a more useful message.