### PR TITLE
Improve readability of log messages

### DIFF
--- a/fiaas_mast/templates/statuspage.html
+++ b/fiaas_mast/templates/statuspage.html
@@ -83,7 +83,7 @@ limitations under the License.
             <div class="collapse in" id="collapseLogs">
                 <div class="well logs">
                     {%- for line in status_object.logs -%}
-                      {{ line }}
+                      <p>{{ line }}</p>
                     {% else -%}
                         There are no logs available right now, please try again later.
                     {%- endfor -%}


### PR DESCRIPTION
Adding a little vertical space between the log lines makes it easier
to identify useful ones when there is an error.