### PR TITLE
Turn InvalidSchema errors into a ClientError

### DIFF
--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -15,7 +15,7 @@
 
 import yaml
 from k8s.models.common import ObjectMeta
-from requests.exceptions import MissingSchema, InvalidURL
+from requests.exceptions import MissingSchema, InvalidURL, InvalidSchema
 
 from .common import dict_merge, generate_random_uuid_string, ClientError
 
@@ -71,8 +71,8 @@ class MetadataGenerator:
     def download_config(self, config_url):
         try:
             resp = self.http_client.get(config_url)
-        except (InvalidURL, MissingSchema) as e:
-            raise ClientError("Invalid config_url") from e
+        except (InvalidURL, MissingSchema, InvalidSchema) as e:
+            raise ClientError("Invalid config_url: {}".format(config_url)) from e
         resp.raise_for_status()
         app_config = yaml.safe_load(resp.text)
         return app_config

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,7 +174,9 @@ def test_generate_paasbeta_application_invalid_config_url(client, config_url, ap
     resp = client.post(application_endpoint, data=dumps(deploy_data), content_type="application/json")
     assert resp.status_code == 422
     response_json = loads(resp.get_data())
-    assert response_json == {"code": 422, "name": "Unprocessable Entity", "description": "Invalid config_url"}
+    assert response_json == {"code": 422,
+                             "name": "Unprocessable Entity",
+                             "description": "Invalid config_url: {}".format(config_url)}
 
 
 def test_generate_configmap(client):


### PR DESCRIPTION
For a config_url with an invalid schema, which will be the case if
an unevaluated Spinnaker-expression is sent in the payload, we can
return an error indicating a problem with the URL, instead of the
generic 500.