### PR TITLE
Return more specific error for invalid YAML

### DIFF
--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -74,5 +74,8 @@ class MetadataGenerator:
         except (InvalidURL, MissingSchema, InvalidSchema) as e:
             raise ClientError("Invalid config_url: {}".format(config_url)) from e
         resp.raise_for_status()
-        app_config = yaml.safe_load(resp.text)
+        try:
+            app_config = yaml.safe_load(resp.text)
+        except yaml.YAMLError as e:
+            raise ClientError("Invalid config YAML: {}".format(e))
         return app_config


### PR DESCRIPTION
If the spec or config fetched is invalid yaml, the response was a
generic 500, without detail on what was causing the error. This changes
it to return the ClientError, with a description indicating the problem.