### PR TITLE
Use additional_[annotations|labels] instead of per-object annotations

### DIFF
--- a/fiaas_mast/application_generator.py
+++ b/fiaas_mast/application_generator.py
@@ -37,10 +37,10 @@ class ApplicationGenerator(MetadataGenerator):
         if not config:
             raise ClientError("Invalid config: {}".format(release.config_url))
 
-        super().merge_tags(release, config)
+        global_tags = {"global": super().merge_tags(release)}
 
-        spec = self.spec_model(image=release.image, application=release.application_name, config=config)
+        global_labels = {"global": super().merge_labels(release)}
+
+        spec = self.spec_model(image=release.image, application=release.application_name, config=config,
+                               additional_annotations=global_tags, additional_labels=global_labels)
         return spec
-
-    def get_annotation_objects(self):
-        return ["deployment", "pod", "service", "ingress", "horizontal_pod_autoscaler"]

--- a/fiaas_mast/fiaas.py
+++ b/fiaas_mast/fiaas.py
@@ -23,10 +23,22 @@ from k8s.fields import Field, RequiredField, ListField
 from k8s.models.common import ObjectMeta
 
 
+class AdditionalLabelsOrAnnotations(Model):
+    _global = Field(dict)
+    deployment = Field(dict)
+    horizontal_pod_autoscaler = Field(dict)
+    ingress = Field(dict)
+    service = Field(dict)
+    pod = Field(dict)
+    status = Field(dict)
+
+
 class FiaasApplicationSpec(Model):
     application = RequiredField(six.text_type)
     image = RequiredField(six.text_type)
     config = RequiredField(dict)
+    additional_labels = Field(AdditionalLabelsOrAnnotations)
+    additional_annotations = Field(AdditionalLabelsOrAnnotations)
 
 
 class FiaasApplication(Model):

--- a/fiaas_mast/models.py
+++ b/fiaas_mast/models.py
@@ -22,6 +22,7 @@ Release = namedtuple("Release", [
     "original_application_name",
     "spinnaker_tags",
     "raw_tags",
+    "raw_labels",
     "metadata_annotations"
 ])
 

--- a/fiaas_mast/web.py
+++ b/fiaas_mast/web.py
@@ -71,6 +71,7 @@ def deploy_handler():
             data["application_name"],
             data.get("spinnaker_tags", {}),
             data.get("raw_tags", {}),
+            data.get("raw_labels", {}),
             data.get("metadata_annotations", {}))
     )
     response = status(namespace, application_name, deployment_id)
@@ -114,6 +115,7 @@ def generate_application():
             data["application_name"],
             data.get("spinnaker_tags", {}),
             data.get("raw_tags", {}),
+            data.get("raw_labels", {}),
             data.get("metadata_annotations", {}))
     )
     return_body = {

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -25,6 +25,7 @@ from fiaas_mast.models import Release
 APPLICATION_NAME = "test_image"
 SPINNAKER_TAGS = {}
 RAW_TAGS = {}
+RAW_LABELS = {}
 DEPLOYMENT_ID = "deadbeef-abba-cafe-1337-baaaaaaaaaad"
 VALID_IMAGE_NAME = "test_image:a1b2c3d"
 VALID_DEPLOY_CONFIG_URL = "http://url_to_config.file"
@@ -148,6 +149,7 @@ class TestCreateDeploymentInK8s(object):
                 APPLICATION_NAME,
                 SPINNAKER_TAGS,
                 RAW_TAGS,
+                RAW_LABELS,
                 ""
             )
         )
@@ -192,6 +194,7 @@ class TestCreateDeploymentInK8s(object):
                 APPLICATION_NAME,
                 SPINNAKER_TAGS,
                 RAW_TAGS,
+                RAW_LABELS,
                 ""
             )
         )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -136,6 +136,12 @@ FIAAS_APPLICATION = {
     "spec": {
         "application": "test-image",
         "image": "test_image:a1b2c3d",
+        "additional_labels": {
+            "global": {}
+        },
+        "additional_annotations": {
+            "global": {}
+        },
         "config": {
             "admin_access": True,
             "healthchecks": {
@@ -160,111 +166,61 @@ FIAAS_APPLICATION = {
 }
 
 ANNOTATIONS_WITH_SPINNAKER_TAGS = {
-    "deployment": {
-        "pipeline.schibsted.io/foo": "bar",
-        "pipeline.schibsted.io/numeric": "1337",
+    "additional_annotations": {
+        "global": {
+            "pipeline.schibsted.io/foo": "bar",
+            "pipeline.schibsted.io/numeric": "1337",
+        }
     },
-    "pod": {
-        "pipeline.schibsted.io/foo": "bar",
-        "pipeline.schibsted.io/numeric": "1337",
-    },
-    "service": {
-        "pipeline.schibsted.io/foo": "bar",
-        "pipeline.schibsted.io/numeric": "1337",
-    },
-    "ingress": {
-        "pipeline.schibsted.io/foo": "bar",
-        "pipeline.schibsted.io/numeric": "1337",
-    },
-    "horizontal_pod_autoscaler": {
-        "pipeline.schibsted.io/foo": "bar",
-        "pipeline.schibsted.io/numeric": "1337",
-    },
+    "additional_labels": {"global": {}}
 }
 
 ANNOTATIONS_WITH_RAW_TAGS = {
-    "deployment": {
-        "my_domain.io/some_annotation": "and_some_value",
-        "my_domain_aux.io/some_annotation": "and_some_value"
+    "additional_annotations": {
+        "global": {
+            "my_domain.io/some_annotation": "and_some_value",
+            "my_domain_aux.io/some_annotation": "and_some_value"
+        }
     },
-    "pod": {
-        "my_domain.io/some_annotation": "and_some_value",
-        "my_domain_aux.io/some_annotation": "and_some_value"
-    },
-    "service": {
-        "my_domain.io/some_annotation": "and_some_value",
-        "my_domain_aux.io/some_annotation": "and_some_value"
-    },
-    "ingress": {
-        "my_domain.io/some_annotation": "and_some_value",
-        "my_domain_aux.io/some_annotation": "and_some_value"
-    },
-    "horizontal_pod_autoscaler": {
-        "my_domain.io/some_annotation": "and_some_value",
-        "my_domain_aux.io/some_annotation": "and_some_value"
-    },
+    "additional_labels": {"global": {}}
+}
+
+ANNOTATIONS_WITH_RAW_LABELS = {
+    "additional_annotations": {"global": {}},
+    "additional_labels": {
+        "global": {
+            "my_domain.io/some_label": "and_some_value",
+            "my_domain.io/some_other_label": "and_some_other_value"
+        }
+    }
 }
 
 ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS = {
-    "deployment": {
-        "i_was_here": "first",
-        "pipeline.schibsted.io/foo": "bar",
+    "additional_annotations": {
+        "global": {
+            "pipeline.schibsted.io/foo": "bar",
+        }
     },
-    "pod": {
-        "pipeline.schibsted.io/foo": "bar",
-    },
-    "service": {
-        "pipeline.schibsted.io/foo": "bar",
-    },
-    "ingress": {
-        "pipeline.schibsted.io/foo": "bar",
-    },
-    "horizontal_pod_autoscaler": {
-        "pipeline.schibsted.io/foo": "bar",
-    },
+    "additional_labels": {"global": {}}
 }
 
 ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS_AND_RAW_TAGS = {
-    "deployment": {
-        "i_was_here": "first",
-        "pipeline.schibsted.io/foo": "bar",
-        'my_domain.io/some_annotation': 'and_some_value'
+    "additional_annotations": {
+        "global": {
+            "pipeline.schibsted.io/foo": "bar",
+            'my_domain.io/some_annotation': 'and_some_value'
+        }
     },
-    "pod": {
-        "pipeline.schibsted.io/foo": "bar",
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "service": {
-        "pipeline.schibsted.io/foo": "bar",
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "ingress": {
-        "pipeline.schibsted.io/foo": "bar",
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "horizontal_pod_autoscaler": {
-        "pipeline.schibsted.io/foo": "bar",
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
+    "additional_labels": {"global": {}}
 }
 
 ANNOTATIONS_WITH_MERGED_RAW_TAGS = {
-    "deployment": {
-        "i_was_here": "first",
-        'my_domain.io/some_annotation': 'and_some_value'
+    "additional_annotations": {
+        "global": {
+            'my_domain.io/some_annotation': 'and_some_value'
+        }
     },
-    "pod": {
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "service": {
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "ingress": {
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
-    "horizontal_pod_autoscaler": {
-        'my_domain.io/some_annotation': 'and_some_value'
-    },
+    "additional_labels": {"global": {}}
 }
 
 
@@ -283,6 +239,7 @@ class TestApplicationGenerator(object):
     def test_generator_creates_object_of_given_type(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
+        raw_labels = {}
 
         http_client = _given_config_url_response_content_is(config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -295,6 +252,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
+                raw_labels,
                 {}
             )
         )
@@ -311,6 +269,7 @@ class TestApplicationGenerator(object):
     def test_generator_annotates_moniker_application(self, config, target_namespace, expected_namespace):
         spinnaker_tags = {}
         raw_tags = {}
+        raw_labels = {}
         metadata_annotation = {
             "moniker.spinnaker.io/application": "unicorn",
             "this_is_a_number": 3,
@@ -336,6 +295,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
+                raw_labels,
                 metadata_annotation
             )
         )
@@ -348,39 +308,57 @@ class TestApplicationGenerator(object):
     def test_generator_adds_spinnaker_annotations(self):
         spinnaker_tags = {'foo': 'bar', 'numeric': 1337}
         raw_tags = {}
+        raw_labels = {}
 
-        self._annotations_verification(spinnaker_tags, raw_tags, ANNOTATIONS_WITH_SPINNAKER_TAGS,
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels, ANNOTATIONS_WITH_SPINNAKER_TAGS,
                                        VALID_DEPLOY_CONFIG_V3)
 
     def test_generator_adds_raw_annotations(self):
         spinnaker_tags = {}
         raw_tags = {'my_domain.io/some_annotation': 'and_some_value',
                     'my_domain_aux.io/some_annotation': 'and_some_value'}
+        raw_labels = {}
 
-        self._annotations_verification(spinnaker_tags, raw_tags, ANNOTATIONS_WITH_RAW_TAGS, VALID_DEPLOY_CONFIG_V3)
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels, ANNOTATIONS_WITH_RAW_TAGS,
+                                       VALID_DEPLOY_CONFIG_V3)
+
+    def test_generator_adds_raw_labels(self):
+        spinnaker_tags = {}
+        raw_tags = {}
+        raw_labels = {
+            'my_domain.io/some_label': 'and_some_value',
+            'my_domain.io/some_other_label': 'and_some_other_value'
+        }
+
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels, ANNOTATIONS_WITH_RAW_LABELS,
+                                       VALID_DEPLOY_CONFIG_V3)
 
     def test_generator_merges_spinnaker_annotations(self):
         spinnaker_tags = {'foo': 'bar'}
         raw_tags = {}
+        raw_labels = {}
 
-        self._annotations_verification(spinnaker_tags, raw_tags, ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS,
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels, ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS,
                                        VALID_DEPLOY_CONFIG_V3_WITH_ANNOTATIONS)
 
     def test_generator_merges_raw_annotations(self):
         spinnaker_tags = {}
         raw_tags = {'my_domain.io/some_annotation': 'and_some_value'}
+        raw_labels = {}
 
-        self._annotations_verification(spinnaker_tags, raw_tags, ANNOTATIONS_WITH_MERGED_RAW_TAGS,
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels, ANNOTATIONS_WITH_MERGED_RAW_TAGS,
                                        VALID_DEPLOY_CONFIG_V3_WITH_ANNOTATIONS)
 
     def test_generator_merges_spinnaker_and_raw_annotations(self):
         spinnaker_tags = {'foo': 'bar'}
         raw_tags = {'my_domain.io/some_annotation': 'and_some_value'}
+        raw_labels = {}
 
-        self._annotations_verification(spinnaker_tags, raw_tags, ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS_AND_RAW_TAGS,
+        self._annotations_verification(spinnaker_tags, raw_tags, raw_labels,
+                                       ANNOTATIONS_WITH_MERGED_SPINNAKER_TAGS_AND_RAW_TAGS,
                                        VALID_DEPLOY_CONFIG_V3_WITH_ANNOTATIONS)
 
-    def _annotations_verification(self, spinnaker_tags, raw_tags, exptected_paasbeta_result, deploy_config):
+    def _annotations_verification(self, spinnaker_tags, raw_tags, raw_labels, exptected_paasbeta_result, deploy_config):
         http_client = _given_config_url_response_content_is(deploy_config)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
         deployment_id, returned_paasbeta_application = generator.generate_application(
@@ -392,15 +370,20 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
+                raw_labels,
                 {}
             )
         )
-        returned_annotations = returned_paasbeta_application.spec.config["annotations"]
+        returned_annotations = {
+            'additional_annotations': returned_paasbeta_application.spec.additional_annotations,
+            'additional_labels': returned_paasbeta_application.spec.additional_labels,
+        }
         assert returned_annotations == exptected_paasbeta_result
 
     def test_generator_without_annotations(self):
         spinnaker_tags = {}
         raw_tags = {}
+        raw_labels = {}
 
         http_client = _given_config_url_response_content_is(VALID_DEPLOY_CONFIG_V3)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -413,6 +396,7 @@ class TestApplicationGenerator(object):
                 APPLICATION_NAME,
                 spinnaker_tags,
                 raw_tags,
+                raw_labels,
                 {}
             )
         )
@@ -422,6 +406,7 @@ class TestApplicationGenerator(object):
         app_name_with_underscores = "test_app"
         spinnaker_tags = {}
         raw_tags = {}
+        raw_labels = {}
 
         http_client = _given_config_url_response_content_is(VALID_DEPLOY_CONFIG_V3)
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -434,6 +419,7 @@ class TestApplicationGenerator(object):
                 app_name_with_underscores,
                 spinnaker_tags,
                 raw_tags,
+                raw_labels,
                 {}
             )
         )
@@ -443,11 +429,13 @@ class TestApplicationGenerator(object):
         assert returned_metadata.labels["app"] == make_safe_name(app_name_with_underscores)
         returned_spec = returned_application.spec
         assert returned_spec.application == make_safe_name(app_name_with_underscores)
-        assert returned_spec.config["annotations"]["mast"]["originalApplicationName"] == app_name_with_underscores
+        assert returned_spec.additional_annotations[
+            "global"]["mast"]["originalApplicationName"] == app_name_with_underscores
 
     def test_generator_with_empty_config(self):
         spinnaker_tags = {}
         raw_tags = {}
+        raw_labels = {}
 
         http_client = _given_config_url_response_content_is("")
         generator = ApplicationGenerator(http_client, create_deployment_id=lambda: DEPLOYMENT_ID)
@@ -462,6 +450,7 @@ class TestApplicationGenerator(object):
                     APPLICATION_NAME,
                     spinnaker_tags,
                     raw_tags,
+                    raw_labels,
                     {}
                 )
             )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -65,6 +65,7 @@ DEFAULT_CONFIG = {
 
 SPINNAKER_TAGS = {}
 RAW_TAGS = {}
+RAW_LABELS = {}
 
 
 @pytest.fixture(autouse=True)
@@ -135,7 +136,7 @@ def test_deploy(client, status):
 
         deploy.assert_called_with(DEFAULT_NAMESPACE,
                                   Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                          RAW_TAGS, {}))
+                                          RAW_TAGS, RAW_LABELS, {}))
         status.assert_called_with("some-namespace", "app-name", "deploy_id")
 
 
@@ -149,7 +150,7 @@ def test_generate_application(client):
         assert urlparse(body["status_url"]).path == "/status/default-namespace/example/deployment_id/"
         generate_application.assert_called_with(
             DEFAULT_NAMESPACE, Release("test_image", "http://example.com", "example", "example", SPINNAKER_TAGS,
-                                       RAW_TAGS, {})
+                                       RAW_TAGS, RAW_LABELS, {})
         )
 
 


### PR DESCRIPTION
Context: The FIAAS app manifest allows you to specify per-object
annotations and labels that are propagated to all objects created
by FIAAS. MAST injects deployment tags (repository, commit sha,
spinnaker monikers, etc.) as annotations to all objects merging
with those from the application spec.

Since some time ago, FIAAS deploy daemon allows specifying "global"
annotations that are replicated to all objects without having to
merge application annotations with those from the deployment
system.

This change makes use of this feature aligning better with how
FIAAS deploy daemon expected annotations to be added. This also
makes the Application spec way less verbose as deployment
annotations only appear once (instead of one per type of object).

This change also introduces a new feature that allows the deployment
system to specify labels alongside annotations, which makes
object filtering using the k8s API way easier and cheaper
by using selectors.

Change-Id: Ia7b065431b88a7db60961c9cd8d210e479459a7c

Pull Request created with [maiao](https://github.schibsted.io/spt-engprod/maiao) currently in beta stage
Please report any bug on slack channel [#spt-engprod](https://sch-chat.slack.com/messages/C2EAQ4PA5) and feel free to contribute or provide feedback