### PR TITLE
Add wrapper around deployment steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ after_success:
   - tox -e coverage
 deploy:
   provider: script
-  script:
-    - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-    - VERSION=$(python setup.py --version) TAG=$(bin/tag_release |tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'
+  script: bin/deploy
   skip_cleanup: true
   on:
     branch: master

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -evuo pipefail
+
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+VERSION=$(python setup.py --version) TAG=$(bin/tag_release |tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'


### PR DESCRIPTION
This fixes an issue where the deployment was not completed correctly. Docker containers were not pushed and helm chart was not created.

From: https://docs.travis-ci.com/user/deployment/script/

If you need to run multiple commands, write a executable wrapper script that runs them all. The argument to script: in the script deployment provider needs to be a single command.