### PR TITLE
[Cert-manager] Update cert-manager annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - mkdir -vp ~/.docker/cli-plugins/
   - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
   - chmod a+x ~/.docker/cli-plugins/docker-buildx
-  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker login --username "${DOCKER_USERNAME}" --password-stdin <<< "${DOCKER_PASSWORD}" && docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 install:
   - bin/install
 script:

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -9,7 +9,8 @@ CACHE_DIR=${PIP_CACHE_DIR:-~/.cache/pip}
 mkdir -p build
 
 if [[ "${CI:-}" == "true" ]]; then
-  PLATFORMS=linux/arm,linux/arm64,linux/amd64
+  #PLATFORMS=linux/arm,linux/arm64,linux/amd64
+  PLATFORMS=linux/amd64
 else
   PLATFORMS=linux/amd64
 fi

--- a/helm/fiaas-mast/templates/ingress.yaml
+++ b/helm/fiaas-mast/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
 {{- end}}
 {{- if .Values.ingress.certIssuer }}
-    certmanager.k8s.io/cluster-issuer: "{{ .Values.ingress.certIssuer }}"
+    {{ .Values.certManager.keyAnnotationPrefix }}/cluster-issuer: "{{ .Values.ingress.certIssuer }}"
 {{- end}}
     kubernetes.io/ingress.class: "{{ .Values.ingress.ingressClass }}"
 {{- if .Values.ingress.whitelistSourceRange }}

--- a/helm/fiaas-mast/values.yaml
+++ b/helm/fiaas-mast/values.yaml
@@ -39,3 +39,10 @@ secrets: # Must be set by user
   artifactoryUser: replace_me
   artifactoryPassword: replace_me
   artifactoryOrigin: replace_me
+
+certManager:
+  # In cert-manager version v0.11.0 (https://github.com/jetstack/cert-manager/releases/tag/v0.11.0) the prefix that cert-manager uses for
+  # annotations was changed. From certmanager.k8s.io to cert-manager.io - see link for more details. In order to allow new behavior this
+  # parameter was added. Keeps previous behaviour but lets overwride for compatibility of newer versions
+  keyAnnotationPrefix: "certmanager.k8s.io"
+


### PR DESCRIPTION
This is for the same reason as https://github.com/fiaas/skipper/pull/105

Since [v0.11.0](https://github.com/jetstack/cert-manager/releases/tag/v0.11.0) that the annotation with certmanager.k8s.io have been renamed to cert-manager.io.

So this PR upgrades the skipper helm chart to match that.