### PR TITLE
Use docker save to store the container

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,5 +47,5 @@ blocks:
             - git config --global user.email "semaphore@example.org"
             - git config --global user.name "Semaphore CI"
             - cache restore ${SEMAPHORE_GIT_BRANCH}-${SEMAPHORE_WORKFLOW_ID}-build
-            - docker tag $(docker import build/mast.tar) $DOCKER_REPO:latest
+            - docker load -i build/mast.tar
             - ./bin/deploy

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -33,18 +33,14 @@ fi
 echo "Buildx nodes:"
 docker buildx ls
 
-# Run multi-arch build
-docker buildx build --pull \
-  --progress plain \
-  --tag "${IMAGE_NAME}:latest" \
-  --platform="${PLATFORMS}" \
-  --output=type=tar,dest="${TARBALL}" .
-
-# Rebuild to load the docker image for local testing
+# Build the docker image for local testing
 docker buildx build --pull \
   --progress plain \
   --tag "${IMAGE_NAME}:latest" \
   --load .
+
+# Save the container to cache for deployment job
+docker save -o "${TARBALL}" "${IMAGE_NAME}:latest"
 
 # Grab the wheels out of the tarball and stuff them in the pip cache directory
 tar -v -C "${CACHE_DIR}/wheels" --wildcards -x "*/wheels/*.whl" -f "${TARBALL}" 2>/dev/null || true


### PR DESCRIPTION
The docker build --output flag seems not to save the json metadata for the image, therefore when we attempted to run the container it failed because the Cmd field was not set.