### PR TITLE
fix: Use .content instead of .text for requests responses

### DIFF
--- a/fiaas_mast/deployer.py
+++ b/fiaas_mast/deployer.py
@@ -52,7 +52,7 @@ class Deployer:
         except (InvalidURL, MissingSchema) as e:
             raise ClientError("Invalid config_url") from e
         resp.raise_for_status()
-        app_config = yaml.safe_load(resp.text)
+        app_config = yaml.safe_load(resp.content)
         return app_config
 
 

--- a/fiaas_mast/metadata_generator.py
+++ b/fiaas_mast/metadata_generator.py
@@ -76,7 +76,7 @@ class MetadataGenerator:
             raise ClientError("Invalid config_url: {}".format(config_url)) from e
         resp.raise_for_status()
         try:
-            app_config = yaml.safe_load(resp.text)
+            app_config = yaml.safe_load(resp.content)
         except yaml.YAMLError as e:
             raise ClientError("Invalid config YAML: {}".format(e))
         return app_config

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -31,7 +31,7 @@ VALID_IMAGE_NAME = "test_image:a1b2c3d"
 VALID_DEPLOY_CONFIG_URL = "http://url_to_config.file"
 ANY_NAMESPACE = "any-namespace"
 
-VALID_DEPLOY_CONFIG = """
+VALID_DEPLOY_CONFIG = b"""
 version: 2
 admin_access: true
 replicas: 1
@@ -48,7 +48,7 @@ config:
   volume: true
 """
 
-VALID_DEPLOY_CONFIG_WITH_NAMESPACE = """
+VALID_DEPLOY_CONFIG_WITH_NAMESPACE = b"""
 version: 2
 namespace: custom-namespace
 admin_access: true
@@ -66,7 +66,25 @@ config:
   volume: true
 """
 
-VALID_DEPLOY_CONFIG_WITH_NAMESPACE_V3 = """
+VALID_DEPLOY_CONFIG_WITH_NON_ISO_8859_1_CHARS = b"""
+version: 2
+namespace: \xc3\x9aj-tal\xc3\xa1latok
+admin_access: true
+replicas: 1
+resources:
+  requests:
+    memory: 128m
+ports:
+  - target_port: 5000
+healthchecks:
+  liveness:
+    http:
+      path: /healthz
+config:
+  volume: true
+"""
+
+VALID_DEPLOY_CONFIG_WITH_NAMESPACE_V3 = b"""
 version: 3
 namespace: custom-namespace
 admin_access: true
@@ -84,13 +102,13 @@ config:
   volume: true
 """
 
-VALID_DEPLOY_CONFIG_WITH_INGRESS_1 = """
+VALID_DEPLOY_CONFIG_WITH_INGRESS_1 = b"""
 version: 3
 ingress:
   - host: foo.example.com
 """
 
-VALID_DEPLOY_CONFIG_WITH_INGRESS_2 = """
+VALID_DEPLOY_CONFIG_WITH_INGRESS_2 = b"""
 version: 3
 """
 
@@ -127,6 +145,7 @@ class TestCreateDeploymentInK8s(object):
 
     @pytest.mark.parametrize("config,target_namespace,expected_namespace", (
         (VALID_DEPLOY_CONFIG, ANY_NAMESPACE, ANY_NAMESPACE),
+        (VALID_DEPLOY_CONFIG_WITH_NON_ISO_8859_1_CHARS, "Új-találatok", "Új-találatok"),
         (VALID_DEPLOY_CONFIG_WITH_NAMESPACE, ANY_NAMESPACE, "custom-namespace"),
         (VALID_DEPLOY_CONFIG_WITH_NAMESPACE_V3, "target-namespace", "target-namespace"),
     ))
@@ -217,7 +236,7 @@ class TestUUID:
 def _given_config_url_response_content_is(config):
     http_client = MagicMock(spec="requests.Session")
     config_response = MagicMock()
-    config_response.text = config
+    config_response.content = config
 
     http_client_get = MagicMock()
     http_client_get.return_value = config_response

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -71,7 +71,8 @@ BASE_CONFIGMAP = {
         "rules.yml": "# put your recording rules here",
         "int_variable": "42",
         "float_variable": "3.14",
-        "boolean_variable": "True"
+        "boolean_variable": "True",
+        "non_ISO8859-1_data": "Új találatok!"
     },
     "kind": "ConfigMap",
     "apiVersion": "v1",
@@ -90,11 +91,12 @@ BASE_CONFIGMAP = {
     }
 }
 
-APPLICATION_DATA = """
+APPLICATION_DATA = b"""
 rules.yml: '# put your recording rules here'
 int_variable: 42
 float_variable: 3.14
 boolean_variable: True
+non_ISO8859-1_data: "\xc3\x9aj tal\xc3\xa1latok!"
 """
 
 EMPTY_BASE_CONFIGMAP = {
@@ -512,7 +514,7 @@ class TestUUID:
 def _given_config_url_response_content_is(config):
     http_client = MagicMock(spec="requests.Session")
     config_response = MagicMock()
-    config_response.text = config
+    config_response.content = config
 
     http_client_get = MagicMock()
     http_client_get.return_value = config_response


### PR DESCRIPTION
As specified in [`requests` documentation](https://docs.python-requests.org/en/master/api/#requests.Response.text), the `.text` method assumes the encoding that the HTTP headers specify. Artifactory's response includes the header "Content-Type: text/plain" which defaults to "ISO-8859-1". 

However, configmaps are allowed to use any utf8 chars. By replacing the `.text` method with `.content`, we use the binary response with no encoding. PyYAML can convert the binary directly and assumes utf8.

Change-Id: I28e32dece5d3c2f855b79225f30de02a8f966718
JIRA: ADELIVHC-684
