### PR TITLE
fix(web.py): Fix generate/configmap response encoding

### DIFF
--- a/fiaas_mast/app.py
+++ b/fiaas_mast/app.py
@@ -55,6 +55,7 @@ def configure_bootstrap(app):
 def configure_app(app, config):
     if config is None:
         config = vars(Config())
+    app.config['JSON_AS_ASCII'] = False
 
     app.config.update(config)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -177,10 +177,11 @@ def test_generate_paasbeta_application_invalid_config_url(client, config_url):
 
 def test_generate_configmap(client):
     with mock.patch.object(ConfigMapGenerator, 'generate_configmap',
-                           return_value=("deployment_id", {"foo": "bar"})) as generate_configmap:
+                           return_value=("deployment_id", {"foo": "bar", "utf8": "ú"})) as generate_configmap:
         resp = client.post("/generate/configmap", data=dumps(VALID_APPLICATIONDATA_REQUEST),
                            content_type="application/json")
         assert resp.status_code == 200
+        assert "ú" in resp.data.decode(resp.charset)
 
         generate_configmap.assert_called_with(
             DEFAULT_NAMESPACE, ApplicationConfiguration("http://example.com", "example", "example", SPINNAKER_TAGS,


### PR DESCRIPTION
Currently, the `jsonify` function is forcing ASCII encoding. This makes responses with utf-8 characters to be incorrectly encoded.

Change-Id: I08275bfc1b12a778f00eeab9c55ed82f756d2591
JIRA: ADELIVHC-684