### PR TITLE
ci(.prospector.yaml): Replace deprecated pep8 and pep257

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -11,7 +11,7 @@ ignore-paths:
   - .tox
   - .cachedocs
 
-pep8:
+pycodestyle:
   options:
     max-line-length: 120
   disable:
@@ -35,5 +35,5 @@ frosted:
 vulture:
   run: false
 
-pep257:
+pydocstyle:
   run: false

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ GEN_REQ = [
 ]
 
 CODE_QUALITY_REQ = [
-    "prospector",
+    "prospector==1.7.7",
 ]
 
 CI_REQ = [


### PR DESCRIPTION
`prospector` has no pinned version, and starting from [version 1.7.0](https://prospector.landscape.io/en/master/changelog.html#version-1-7-0) `pep8` and `pep257` are replaced with `pycodestyle` and `pydocstyle` respectively.