### PR TITLE
Customize certmanager key annotation suffix

### DIFF
--- a/helm/fiaas-mast/templates/ingress.yaml
+++ b/helm/fiaas-mast/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
 {{- end}}
 {{- if .Values.ingress.certIssuer }}
-    {{ .Values.certManager.keyAnnotationPrefix }}/cluster-issuer: "{{ .Values.ingress.certIssuer }}"
+    {{ .Values.certManager.keyAnnotationPrefix }}/{{ .Values.certManager.keyAnnotationSuffix }}: "{{ .Values.ingress.certIssuer }}"
 {{- end}}
     kubernetes.io/ingress.class: "{{ .Values.ingress.ingressClass }}"
 {{- if .Values.ingress.whitelistSourceRange }}

--- a/helm/fiaas-mast/values.yaml
+++ b/helm/fiaas-mast/values.yaml
@@ -45,4 +45,4 @@ certManager:
   # annotations was changed. From certmanager.k8s.io to cert-manager.io - see link for more details. In order to allow new behavior this
   # parameter was added. Keeps previous behaviour but lets overwride for compatibility of newer versions
   keyAnnotationPrefix: "certmanager.k8s.io"
-
+  keyAnnotationSuffix: "cluster-issuer"


### PR DESCRIPTION
We need a new annotation suffix required by our k8s cluster maintainer team. This template will allow us to customize it.