### PR TITLE
Use fiaas/k8s built-in in-cluster configuration to support time-based refreshing service account tokens

### DIFF
--- a/fiaas_mast/app.py
+++ b/fiaas_mast/app.py
@@ -80,8 +80,17 @@ def configure_logging():
 
 def configure_k8s_client(app):
     k8s_config.debug = True
-    k8s_config.api_token = app.config.get('APISERVER_TOKEN')
-    k8s_config.verify_ssl = app.config.get('APISERVER_CA_CERT')
+
+    if app.config.get('APISERVER_TOKEN'):
+        k8s_config.api_token = app.config.get('APISERVER_TOKEN')
+    else:
+        # use default in-cluster config if api_token is not explicitly set
+        # sets api_token_source and verify_ssl
+        k8s_config.use_in_cluster_config()
+
+    # if api_cert is explicitly set, override in-cluster config setting (if used)
+    if app.config.get('APISERVER_CA_CERT'):
+        k8s_config.verify_ssl = app.config.get('APISERVER_CA_CERT')
 
 
 def error_handler(error):

--- a/fiaas_mast/config.py
+++ b/fiaas_mast/config.py
@@ -34,30 +34,7 @@ class Config(object):
         self.scheme = os.environ.get('URL_SCHEME', 'https')
 
     def get_apiserver_token(self):
-        token = os.environ.get('APISERVER_TOKEN')
-        if token is None:
-            token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-            if os.path.exists(token_path):
-                with open(token_path) as fobj:
-                    return fobj.read().strip()
-            else:
-                raise RuntimeError(
-                    "Could not resolve apiserver token. No $APISERVER_TOKEN set in the environment and "
-                    "{} did not exist.".format(token_path)
-                )
-
-        return token
+        return os.environ.get('APISERVER_TOKEN')
 
     def get_apiserver_cert(self):
-        cert = os.environ.get('APISERVER_CA_CERT')
-        if cert is None:
-            ca_cert_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-            if os.path.exists(ca_cert_path):
-                return ca_cert_path
-            else:
-                raise RuntimeError(
-                    "Could not resolve apiserver CA certificate. No $APISERVER_CA_CERT set in the "
-                    "environment and {} did not exist.".format(ca_cert_path)
-                )
-
-        return cert
+        return os.environ.get('APISERVER_CA_CERT')

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ GEN_REQ = [
     "requests==2.22.0",
     "six==1.12.0",
     "ipaddress==1.0.22",
-    "k8s==0.13.0",
+    "k8s==0.21.0",
     "prometheus_client == 0.7.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,6 @@ GEN_REQ = [
     "ipaddress==1.0.22",
     "k8s==0.21.0",
     "prometheus_client == 0.7.1",
-    "jinja2<3.1.0",
-    "itsdangerous==2.0.1",
-    "werkzeug==2.0.3",
 ]
 
 CODE_QUALITY_REQ = [

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ GEN_REQ = [
     "ipaddress==1.0.22",
     "k8s==0.21.0",
     "prometheus_client == 0.7.1",
+    "jinja2<3.1.0",
+    "itsdangerous==2.0.1",
+    "werkzeug==2.0.3",
 ]
 
 CODE_QUALITY_REQ = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import pytest
 
 from fiaas_mast.config import Config
@@ -38,51 +37,6 @@ class TestConfig(object):
         assert config.ARTIFACTORY_USER == username
         assert config.ARTIFACTORY_PWD == password
         assert config.ARTIFACTORY_ORIGIN == origin
-
-    def test_k8s_token_is_read_from_file_when_env_is_not_defined(self, monkeypatch):
-        token = "token"
-        monkeypatch.setenv("APISERVER_CA_CERT", "/path/to/the/ca.crt")
-        monkeypatch.setenv("ARTIFACTORY_USER", "username")
-        monkeypatch.setenv("ARTIFACTORY_PWD", "password")
-        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
-
-        with mock.patch("builtins.open", mock.mock_open(read_data=token)), mock.patch("os.path.exists") as exists:
-            exists.return_value = True
-            config = Config()
-            assert config.APISERVER_TOKEN == token
-
-    def test_k8s_cert_is_read_from_file_when_env_is_not_defined(self, monkeypatch):
-        certificate = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        monkeypatch.setenv("APISERVER_TOKEN", "token")
-        monkeypatch.setenv("ARTIFACTORY_USER", "username")
-        monkeypatch.setenv("ARTIFACTORY_PWD", "password")
-        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
-
-        with mock.patch("os.path.exists") as exists:
-            exists.return_value = True
-            config = Config()
-            assert config.APISERVER_CA_CERT == certificate
-
-    def test_k8s_config_apiserver_token_missing(self, monkeypatch):
-        certificate = "/path/to/the/ca.crt"
-        monkeypatch.setenv("APISERVER_CA_CERT", certificate)
-        monkeypatch.setenv("ARTIFACTORY_USER", "username")
-        monkeypatch.setenv("ARTIFACTORY_PWD", "password")
-        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
-
-        with pytest.raises(RuntimeError):
-            config = Config()
-            config.APISERVER_TOKEN
-
-    def test_k8s_config_apiserver_ca_cert_missing(self, monkeypatch):
-        monkeypatch.setenv("APISERVER_TOKEN", "thetoken")
-        monkeypatch.setenv("ARTIFACTORY_USER", "username")
-        monkeypatch.setenv("ARTIFACTORY_PWD", "password")
-        monkeypatch.setenv("ARTIFACTORY_ORIGIN", "origin")
-
-        with pytest.raises(RuntimeError):
-            config = Config()
-            config.APISERVER_CA_CERT
 
     def test_artifactory_credentials_are_missing(self, monkeypatch):
         monkeypatch.setenv("APISERVER_TOKEN", "token")


### PR DESCRIPTION
This is to support regularly re-reading the service account token
from file when in-cluster configuration is used.