### PR TITLE
Update api used for ingress to support kubernetes 1.22

### DIFF
--- a/helm/fiaas-mast/templates/ingress.yaml
+++ b/helm/fiaas-mast/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
extensions/v1beta1 is deprecated in kubernetes 1.22 bump the version.