### PR TITLE
Use python 3.9 and ubuntu2004 CI image

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Mast docker build
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - name: build
     task:
@@ -17,7 +17,7 @@ blocks:
         - name: build
           commands:
             - checkout
-            - sem-version python 3.6
+            - sem-version python 3.9
             - cache restore ${SEMAPHORE_GIT_BRANCH}-pip
             - pip install --quiet --no-color .[ci]
             - cache delete ${SEMAPHORE_GIT_BRANCH}-pip
@@ -43,7 +43,7 @@ blocks:
         - name: deploy
           commands:
             - checkout
-            - sem-version python 3.6
+            - sem-version python 3.9
             - git config --global user.email "semaphore@example.org"
             - git config --global user.name "Semaphore CI"
             - cache restore ${SEMAPHORE_GIT_BRANCH}-${SEMAPHORE_WORKFLOW_ID}-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6-alpine3.7 as common
+FROM python:3.9-alpine3.19 as common
 LABEL maintainer="fiaas <fiaas@googlegroups.com>"
 
-RUN apk --no-cache add --update ca-certificates tini=0.16.1-r0 yaml && \
+RUN apk --no-cache add --update ca-certificates tini=0.19.0-r2 yaml && \
     mkdir -p /opt/fiaas-mast && \
     adduser -u 10001 -D -h /opt/fiaas-mast fiaas-mast
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Kubernetes cluster.
 Development
 -----------
 
-The Development target is Python 3.6.
+The Development target is Python 3.9.
 
 Install dependencies using `pip`:
 

--- a/fiaas_mast/fiaas.py
+++ b/fiaas_mast/fiaas.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import
 
-import six
 from k8s.base import Model
 from k8s.fields import Field, RequiredField, ListField
 from k8s.models.common import ObjectMeta
@@ -34,8 +33,8 @@ class AdditionalLabelsOrAnnotations(Model):
 
 
 class FiaasApplicationSpec(Model):
-    application = RequiredField(six.text_type)
-    image = RequiredField(six.text_type)
+    application = RequiredField(str)
+    image = RequiredField(str)
     config = RequiredField(dict)
     additional_labels = Field(AdditionalLabelsOrAnnotations)
     additional_annotations = Field(AdditionalLabelsOrAnnotations)
@@ -47,8 +46,8 @@ class FiaasApplication(Model):
         watch_list_url = "/apis/fiaas.schibsted.io/v1/watch/applications"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
-    kind = Field(six.text_type, "Application")
+    apiVersion = Field(str, "fiaas.schibsted.io/v1")
+    kind = Field(str, "Application")
 
     metadata = Field(ObjectMeta)
     spec = Field(FiaasApplicationSpec)
@@ -60,12 +59,12 @@ class FiaasStatus(Model):
         url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/statuses/{name}"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
-    kind = Field(six.text_type, "Status")
+    apiVersion = Field(str, "fiaas.schibsted.io/v1")
+    kind = Field(str, "Status")
 
     metadata = Field(ObjectMeta)
-    result = Field(six.text_type)
-    logs = ListField(six.text_type)
+    result = Field(str)
+    logs = ListField(str)
 
 
 class FiaasApplicationStatus(Model):
@@ -73,9 +72,9 @@ class FiaasApplicationStatus(Model):
         url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/application-statuses/{name}"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
-    kind = Field(six.text_type, "ApplicationStatus")
+    apiVersion = Field(str, "fiaas.schibsted.io/v1")
+    kind = Field(str, "ApplicationStatus")
 
     metadata = Field(ObjectMeta)
-    result = Field(six.text_type)
-    logs = ListField(six.text_type)
+    result = Field(str)
+    logs = ListField(str)

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,15 @@ GEN_REQ = [
     "Flask==1.1.1",
     "flask-talisman==0.7.0",
     "flask-bootstrap==3.3.7.1",
+    "itsdangerous==2.0.1", # pinned for Flask 1.x
+    "jinja2==3.0.3", # pinned for flask 1.x
+    "markupsafe==2.0.1", # pinned for flask 1.x
+    "werkzeug==2.0.3", # pinned for flask 1.x
     "pyyaml>=5.4",
-    "requests==2.22.0",
+    "requests==2.31.0",
+    "urllib3==1.26.17",
     "ipaddress==1.0.22",
-    "k8s==0.21.0",
+    "k8s==0.24.2",
     "prometheus_client == 0.7.1",
 ]
 
@@ -51,8 +56,7 @@ CODE_QUALITY_REQ = [
 ]
 
 CI_REQ = [
-    "tox==3.13.2",
-    "tox-travis==0.12",
+    "tox==3.28.0",
 ]
 
 TEST_REQ = [

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ CI_REQ = [
 ]
 
 TEST_REQ = [
-    'mock==3.0.5',
     'pytest-sugar==0.9.2',
     'pytest==3.10.1',
     "pytest-cov==2.7.1",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ GEN_REQ = [
     "flask-bootstrap==3.3.7.1",
     "pyyaml>=5.4",
     "requests==2.22.0",
-    "six==1.12.0",
     "ipaddress==1.0.22",
     "k8s==0.21.0",
     "prometheus_client == 0.7.1",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,7 +17,7 @@
 
 import pytest
 from k8s.client import NotFound
-from mock import patch
+from unittest.mock import patch
 
 from fiaas_mast.common import check_models, PlatformError
 from fiaas_mast.fiaas import FiaasApplication, FiaasApplicationSpec

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -16,7 +16,7 @@
 import pytest
 import yaml
 from k8s.models.common import ObjectMeta
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from fiaas_mast.deployer import generate_random_uuid_string, Deployer
 from fiaas_mast.fiaas import FiaasApplicationSpec, FiaasApplication

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from fiaas_mast.application_generator import ApplicationGenerator
 from fiaas_mast.common import generate_random_uuid_string

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 
-import mock
+from unittest import mock
 import os.path
 import pytest
 import yaml

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -16,7 +16,7 @@
 from json import loads, dumps
 from urllib.parse import urlparse
 
-import mock
+from unittest import mock
 import pytest
 
 from fiaas_mast.app import create_app

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py36
+envlist = py39
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
The ubuntu1804 CI image is deprecated[1], and the oldest python version
available in the newer CI image is 3.9. Upgrade to Python 3.9 and switch to the newer worker image to be able to continue building in CI.

Several dependencies are pinned at older versions and should really be upgraded, but I think it is better to do that separately.

[1]: https://semaphoreci.com/blog/deprecating-ubuntu-18.04-in-semaphore